### PR TITLE
Bugfix teleport in mindscape and fly overworld

### DIFF
--- a/common/src/main/java/dev/munebase/hexkeys/mixin/HexkeysEntityDataSaverMixin.java
+++ b/common/src/main/java/dev/munebase/hexkeys/mixin/HexkeysEntityDataSaverMixin.java
@@ -25,6 +25,12 @@ public abstract class HexkeysEntityDataSaverMixin implements IEntityDataSaver
 		return persistentData;
 	}
 
+	@Override
+	public void setPersistentNbtData(NbtCompound persistentData)
+	{
+		this.persistentData = persistentData;
+	}
+
 	@Inject(method = "writeNbt", at = @At("HEAD"))
 	protected void injectWriteMethod(NbtCompound nbt, CallbackInfoReturnable info)
 	{

--- a/common/src/main/java/dev/munebase/hexkeys/mixin/HexkeysEntityPlayerDataCopyAfterDeathMixin.java
+++ b/common/src/main/java/dev/munebase/hexkeys/mixin/HexkeysEntityPlayerDataCopyAfterDeathMixin.java
@@ -1,0 +1,18 @@
+package dev.munebase.hexkeys.mixin;
+
+import dev.munebase.hexkeys.utils.IEntityDataSaver;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayerEntity.class)
+public abstract class HexkeysEntityPlayerDataCopyAfterDeathMixin implements IEntityDataSaver
+{
+	@Inject(method = "copyFrom", at = @At("TAIL"))
+    public void InjectCopyFrom(ServerPlayerEntity oldPlayer, boolean alive, CallbackInfo info)
+    {
+        this.setPersistentNbtData(oldPlayer.getPersistentNbtData());
+    }
+}

--- a/common/src/main/java/dev/munebase/hexkeys/utils/DimensionHelper.java
+++ b/common/src/main/java/dev/munebase/hexkeys/utils/DimensionHelper.java
@@ -95,18 +95,17 @@ public class DimensionHelper
 				z = sharedSpawnPos.getZ();
 			}
 			player.getAbilities().allowFlying = mindNBT.getBoolean(NBTKeys.LAST_DIMENSION_COULD_FLY); // Remove flying if they aren't in creative mode
+			if (!player.getAbilities().allowFlying && player.getAbilities().flying) player.getAbilities().flying = false;
 		}
 		else
 		{
 			destination = getOrCreateMindscape(mindscapeOwnerUUID, new BlockPos(x, y, z), server);
-			player.getAbilities().allowFlying = true; // Allow flight in the mind
 		}
 
 		Identifier location = player.getEntityWorld().getDimensionKey().getValue();
 
 		if (!isInMindscape(player))
 		{
-			mindNBT = PlayerHelper.getPersistentTag(player, Hexkeys.IDENTIFIER.toString());
 			// XYZ
 			mindNBT.putDouble(NBTKeys.LAST_DIMENSION_X, player.getX());
 			mindNBT.putDouble(NBTKeys.LAST_DIMENSION_Y, player.getY());
@@ -118,6 +117,7 @@ public class DimensionHelper
 
 			// save if they could fly pre-mindscape or not
 			mindNBT.putBoolean(NBTKeys.LAST_DIMENSION_COULD_FLY, player.getAbilities().allowFlying);
+			player.getAbilities().allowFlying = true; // Allow flight in the mind
 		}
 
 		Vector3d newPosByDestination = new Vector3d(x,y,z);

--- a/common/src/main/java/dev/munebase/hexkeys/utils/IEntityDataSaver.java
+++ b/common/src/main/java/dev/munebase/hexkeys/utils/IEntityDataSaver.java
@@ -7,4 +7,6 @@ public interface IEntityDataSaver
 	default NbtCompound getPersistentNbtData() {
 		return new NbtCompound();
 	};
+
+	default void setPersistentNbtData(NbtCompound persistentData) {};
 }

--- a/common/src/main/resources/hexkeys-common.mixins.json
+++ b/common/src/main/resources/hexkeys-common.mixins.json
@@ -7,7 +7,8 @@
     "HexkeysMixin"
   ],
   "mixins": [
-    "HexkeysEntityDataSaverMixin"
+    "HexkeysEntityDataSaverMixin",
+    "HexkeysEntityPlayerDataCopyAfterDeathMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Я произвёл фиксы для бага полёта в обычном мире и неверной телепортации в библиотеку разума.

Теперь НБТ HexKeys не будут пропадать после смерти.

Google translate added by Moonlit:
I made fixes for the bug of flight in the normal world and incorrect teleportation to the library of the mind.

Now NBT HexKeys will not disappear after death.